### PR TITLE
Support additional folder level if x-tag-groups field exists for v1

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -858,10 +858,112 @@ module.exports = {
    * @returns {object} returns an object containing objects of tags and their requests
    */
   addCollectionItemsUsingTags: function(spec, generatedStore, components, options, schemaCache) {
+    var variableStore = {};
+    if (this._isTagGroupsDefined(spec, 'x-tag-groups') || this._isTagGroupsDefined(spec, 'x-tagGroups')) {
+      this._buildCollectionItemsFromTagGroups(spec, generatedStore, components, options, schemaCache, variableStore);
+    }
+    else {
+      this._buildCollectionItemsFromTags(spec, generatedStore, components, options, schemaCache, variableStore);
+    }
+
+    // variableStore contains all the kinds of variable created.
+    // Add only the variables with type 'collection' to generatedStore.collection.variables
+    _.forEach(variableStore, (variable) => {
+      if (variable.type === 'collection') {
+        const collectionVar = new sdk.Variable(variable);
+        generatedStore.collection.variables.add(collectionVar);
+      }
+    });
+  },
+
+  _isTagGroupsDefined: function(spec, tagGroupsKey) {
+    return tagGroupsKey in spec && Boolean(spec[tagGroupsKey]) && spec[tagGroupsKey].length > 0;
+  },
+
+  _buildCollectionItemsFromTagGroups: function(spec, generatedStore, components, options, schemaCache, variableStore) {
     var globalTags = spec.tags || [],
-      paths = spec.paths || {},
-      pathMethods,
-      variableStore = {},
+      globalXTagGroups = spec['x-tag-groups'] || spec['x-tagGroups'] || [],
+      otherGroup = {
+        // description: 'Requests without X-TAG-GROUP',
+        // requests: []
+      },
+      tagGroupFolders = {};
+
+    // add global x-tag-group to result
+    globalXTagGroups.forEach((tagGroup) => {
+      tagGroupFolders[tagGroup.name] = {};
+      _.forEach(tagGroup.tags, (tag) => {
+        tagGroupFolders[tagGroup.name][tag] = {
+          description: '',
+          requests: []
+        };
+      });
+    });
+
+    // common function to map all paths in spec and use localTags from this paths
+    this._mapPaths(spec, generatedStore, components, options, schemaCache, variableStore, (localTag, requestObj) => {
+      let xTagGroup = this.getTagGroupByTag(globalXTagGroups, localTag);
+      if (!xTagGroup) {
+        // add new unknown tag object to OTHERS
+        if (!_.has(otherGroup, localTag)) {
+          otherGroup[localTag] = {
+            description: '',
+            requests: []
+          };
+        }
+        otherGroup[localTag].requests.push(requestObj);
+        return;
+      }
+
+      tagGroupFolders[xTagGroup][localTag].requests.push(requestObj);
+    });
+
+    // remove empty tags and tag groups
+    Object.keys(tagGroupFolders).forEach((tagGroup) => {
+      Object.keys(tagGroupFolders[tagGroup]).forEach((tag) => {
+        if (tagGroupFolders[tagGroup][tag].requests.length === 0) {
+          delete tagGroupFolders[tagGroup][tag];
+        }
+      });
+      if (Object.keys(tagGroupFolders[tagGroup]).length === 0) {
+        delete tagGroupFolders[tagGroup];
+      }
+    });
+
+    // add Others group
+    if (Object.keys(otherGroup).length > 0) {
+      tagGroupFolders['Others'] = otherGroup;
+    }
+    // Add all folders created from tags and corresponding operations
+    // Iterate from bottom to top order to maintain tag order in spec
+    _.forEachRight(tagGroupFolders, (tagFolders, tagGroupName) => {
+      var itemGroup = new sdk.ItemGroup({
+        name: tagGroupName
+        // description: tagFolder.description
+      });
+
+      _.forEach(tagFolders, (tagFolder, tagName) => {
+        let globalTag = globalTags.find((tag) => { return tag.name === tagName; });
+        const tagDescription = globalTag ? (globalTag.description ? globalTag.description : '') : '',
+          itemInnerGroup = new sdk.ItemGroup({
+            name: tagName,
+            description: tagDescription
+          });
+
+        _.forEach(tagFolder.requests, (request) => {
+          // eslint-disable-next-line max-len
+          itemInnerGroup.items.add(this.convertRequestToItem(spec, request, components, options, schemaCache, variableStore));
+        });
+        itemGroup.items.add(itemInnerGroup);
+      });
+
+      // Add folders first (before requests) in generated collection
+      generatedStore.collection.items.prepend(itemGroup);
+    });
+  },
+
+  _buildCollectionItemsFromTags: function(spec, generatedStore, components, options, schemaCache, variableStore) {
+    var globalTags = spec.tags || [],
       tagFolders = {};
 
     // adding globalTags in the tagFolder object that are defined at the root level
@@ -871,6 +973,39 @@ module.exports = {
         requests: []
       };
     });
+
+    this._mapPaths(spec, generatedStore, components, options, schemaCache, variableStore, (localTag, requestObj) => {
+      // add undefined tag object with empty description
+      if (!_.has(tagFolders, localTag)) {
+        tagFolders[localTag] = {
+          description: '',
+          requests: []
+        };
+      }
+
+      tagFolders[localTag].requests.push(requestObj);
+    });
+
+    // Add all folders created from tags and corresponding operations
+    // Iterate from bottom to top order to maintain tag order in spec
+    _.forEachRight(tagFolders, (tagFolder, tagName) => {
+      var itemGroup = new sdk.ItemGroup({
+        name: tagName,
+        description: tagFolder.description
+      });
+
+      _.forEach(tagFolder.requests, (request) => {
+        itemGroup.items.add(this.convertRequestToItem(spec, request, components, options, schemaCache, variableStore));
+      });
+
+      // Add folders first (before requests) in generated collection
+      generatedStore.collection.items.prepend(itemGroup);
+    });
+  },
+
+  _mapPaths: function(spec, generatedStore, components, options, schemaCache, variableStore, processLocalTagCallback) {
+    var paths = spec.paths || {},
+      pathMethods;
 
     _.forEach(paths, (currentPathObject, path) => {
       var commonParams = [],
@@ -937,15 +1072,7 @@ module.exports = {
         }
         else {
           _.forEach(localTags, (localTag) => {
-            // add undefined tag object with empty description
-            if (!_.has(tagFolders, localTag)) {
-              tagFolders[localTag] = {
-                description: '',
-                requests: []
-              };
-            }
-
-            tagFolders[localTag].requests.push({
+            return processLocalTagCallback(localTag, {
               name: summary,
               method: pathMethod,
               path: path,
@@ -957,34 +1084,24 @@ module.exports = {
         }
       });
     });
+  },
 
-    // Add all folders created from tags and corresponding operations
-    // Iterate from bottom to top order to maintain tag order in spec
-    _.forEachRight(tagFolders, (tagFolder, tagName) => {
-      var itemGroup = new sdk.ItemGroup({
-        name: tagName,
-        description: tagFolder.description
-      });
-
-      _.forEach(tagFolder.requests, (request) => {
-        if (shouldAddDeprecatedOperation(request.properties, options)) {
-          itemGroup.items.add(
-            this.convertRequestToItem(spec, request, components, options, schemaCache, variableStore));
-        }
-      });
-
-      // Add folders first (before requests) in generated collection
-      generatedStore.collection.items.prepend(itemGroup);
+  /**
+   * @TODO: prepare doc
+   * @param xTagGroups
+   * @param tag
+   * @returns {null|*}
+   */
+  getTagGroupByTag: function(xTagGroups, tag) {
+    let requiredTagGroup = xTagGroups.find((xTagGroup) => {
+      return xTagGroup.tags.indexOf(tag) !== -1;
     });
 
-    // variableStore contains all the kinds of variable created.
-    // Add only the variables with type 'collection' to generatedStore.collection.variables
-    _.forEach(variableStore, (variable) => {
-      if (variable.type === 'collection') {
-        const collectionVar = new sdk.Variable(variable);
-        generatedStore.collection.variables.add(collectionVar);
-      }
-    });
+    if (!requiredTagGroup) {
+      return null;
+    }
+
+    return requiredTagGroup.name;
   },
 
   /**
@@ -5364,3 +5481,4 @@ module.exports = {
 
   verifyDeprecatedProperties: verifyDeprecatedProperties
 };
+


### PR DESCRIPTION
Add additional folder level for x-tag-groups extension field for v1 generator.  
Current usage:

    openapi2postmanv2 -s "C:\Users\dyadyajora\Downloads\api-reference.yml" -i v1 -o out.json -p -O folderStrategy=tags