### PR TITLE
Support TagGroups folderStrategy for V2

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -22,4 +22,4 @@ enableOptionalParameters|boolean|-|true|Optional parameters aren't selected in t
 keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers from the OpenAPI specification, which are removed by default.|CONVERSION|v2, v1
 includeDeprecated|boolean|-|true|Select whether to include deprecated operations, parameters, and properties in generated collection or not|CONVERSION, VALIDATION|v2, v1
 alwaysInheritAuthentication|boolean|-|false|Whether authentication details should be included on every request, or always inherited from the collection.|CONVERSION|v2, v1
-othersFolder|string|-|""|Move untagged paths when `folderStrategy` is `Tags` or `TagGroups` to separate folder with custom name. If value is not set, put this paths to root.|CONVERSION|v2
+othersFolder|string|-|""|Move untagged paths when `folderStrategy` is `Tags` or `TagGroups` to separate folder with custom name. If value is not set, put this paths to root.|CONVERSION|v2, v1

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -7,7 +7,7 @@ optimizeConversion|boolean|-|true|Optimizes conversion for large specification, 
 requestParametersResolution|enum|Example, Schema|Schema|Select whether to generate the request parameters based on the [schema](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject) or the [example](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject) in the schema.|CONVERSION|v1
 exampleParametersResolution|enum|Example, Schema|Example|Select whether to generate the response parameters based on the [schema](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject) or the [example](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject) in the schema.|CONVERSION|v1
 parametersResolution|enum|Example, Schema|Schema|Select whether to generate the request and response parameters based on the [schema](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject) or the [example](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject) in the schema.|CONVERSION|v2, v1
-folderStrategy|enum|Paths, Tags|Paths|Select whether to create folders according to the spec’s paths or tags.|CONVERSION|v2, v1
+folderStrategy|enum|Paths, Tags, TagGroups|Paths|Select whether to create folders according to the spec’s paths or tags.|CONVERSION|v2, v1
 includeAuthInfoInExample|boolean|-|true|Select whether to include authentication parameters in the example request.|CONVERSION|v2, v1
 shortValidationErrors|boolean|-|false|Whether detailed error messages are required for request <> schema validation operations.|VALIDATION|v2, v1
 validationPropertiesToIgnore|array|-|[]|Specific properties (parts of a request/response pair) to ignore during validation. Must be sent as an array of strings. Valid inputs in the array: PATHVARIABLE, QUERYPARAM, HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY|VALIDATION|v2, v1
@@ -22,3 +22,4 @@ enableOptionalParameters|boolean|-|true|Optional parameters aren't selected in t
 keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers from the OpenAPI specification, which are removed by default.|CONVERSION|v2, v1
 includeDeprecated|boolean|-|true|Select whether to include deprecated operations, parameters, and properties in generated collection or not|CONVERSION, VALIDATION|v2, v1
 alwaysInheritAuthentication|boolean|-|false|Whether authentication details should be included on every request, or always inherited from the collection.|CONVERSION|v2, v1
+othersFolder|string|-|""|Move untagged paths when `folderStrategy` is `Tags` or `TagGroups` to separate folder with custom name. If value is not set, put this paths to root.|CONVERSION|v2

--- a/lib/options.js
+++ b/lib/options.js
@@ -171,7 +171,7 @@ module.exports = {
         id: 'folderStrategy',
         type: 'enum',
         default: 'Paths',
-        availableOptions: ['Paths', 'Tags'],
+        availableOptions: ['Paths', 'Tags', 'TagGroups'],
         description: 'Select whether to create folders according to the spec’s paths or tags.',
         external: true,
         usage: ['CONVERSION'],

--- a/lib/options.js
+++ b/lib/options.js
@@ -386,6 +386,18 @@ module.exports = {
         usage: ['CONVERSION'],
         supportedIn: [VERSION20, VERSION30, VERSION31],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
+      },
+      {
+        name: 'Move untagged paths to separate folder',
+        id: 'othersFolder',
+        type: 'string',
+        default: '',
+        description: 'Move untagged paths when `folderStrategy` is `Tags` or `TagGroups` to separate folder with ' +
+          'custom name. If value is not set, put this paths to root.',
+        external: true,
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       }
     ];
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,6 +78,15 @@ module.exports = {
             }
             break;
 
+          case 'string':
+            if (_.isString(userOptions[id])) {
+              retVal[id] = userOptions[id];
+            }
+            else {
+              retVal[id] = defaultOptions[id].default;
+            }
+            break;
+
           default:
             retVal[id] = defaultOptions[id].default;
         }

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -30,7 +30,9 @@ const optionIds = [
     'includeDeprecated',
     'parametersResolution',
     'disabledParametersValidation',
-    'alwaysInheritAuthentication'
+    'alwaysInheritAuthentication',
+    'othersFolder',
+    'includeWebhooks'
   ],
   expectedOptions = {
     collapseFolders: {

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -293,7 +293,7 @@ describe('The convert v2 Function', function() {
   });
 
   // Need to handle collaping of folders
-  it.skip('Should generate collection with collapsing unnecessary folders ' +
+  it('Should generate collection with collapsing unnecessary folders ' +
   multipleFoldersSpec, function(done) {
     var openapi = fs.readFileSync(multipleFoldersSpec, 'utf8');
     Converter.convertV2({ type: 'string', data: openapi }, {}, (err, conversionResult) => {
@@ -305,7 +305,7 @@ describe('The convert v2 Function', function() {
       done();
     });
   });
-  it.skip('Should collapse child and parent folder when parent has only one child' +
+  it('Should collapse child and parent folder when parent has only one child' +
   multipleFoldersSpec1, function(done) {
     var openapi = fs.readFileSync(multipleFoldersSpec1, 'utf8');
     Converter.convertV2({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
@@ -319,7 +319,7 @@ describe('The convert v2 Function', function() {
       done();
     });
   });
-  it.skip('Should generate collection without creating folders and having only one request' +
+  it('Should generate collection without creating folders and having only one request' +
   multipleFoldersSpec2, function(done) {
     var openapi = fs.readFileSync(multipleFoldersSpec2, 'utf8');
     Converter.convertV2({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {


### PR DESCRIPTION
* Support folder strategy for x-tagGroups
* Add new option value for `folderStrategy`: tagGroups
* Add new option `othersFolder` to group untagged paths into separate folder: if empty - behaviour by default, if set - move untagged paths to folder with name from option value

Usage:

    openapi2postmanv2 -s spec.yml -o out.json -p -O folderStrategy=tagGroups,othersFolder=Others