### PR TITLE
Add feature to filter responses in generated collections with `includeResponse` option

### DIFF
--- a/bin/openapi2postmanv2.js
+++ b/bin/openapi2postmanv2.js
@@ -50,6 +50,14 @@ function parseOptions (value) {
   if (_.has(parsedOptions, 'requestParametersResolution') && !_.has(parsedOptions, 'parametersResolution')) {
     parsedOptions.parametersResolution = parsedOptions.requestParametersResolution;
   }
+  
+  /**
+   * Map to string existing status codes in includeResponses
+   */
+  if (_.has(parsedOptions, 'includeResponses')) {
+    parsedOptions.includeResponses = parsedOptions.includeResponses.map(code => code + '');
+  }
+
   return parsedOptions;
 }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -386,6 +386,18 @@ module.exports = {
         usage: ['CONVERSION'],
         supportedIn: [VERSION20, VERSION30, VERSION31],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
+      },
+      {
+        name: 'Response status codes to generate in collection',
+        id: 'includeResponses',
+        type: 'array',
+        default: null,
+        description: 'Array of valid HTTP status codes to filter generated response examples only by selected error codes. ' +
+          'Null value disables filtering.',
+        external: true,
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31],
+        supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       }
     ];
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2766,6 +2766,10 @@ module.exports = {
       }
 
       _.forOwn(operation.responses, (response, code) => {
+        if (context.computedOptions.includeResponses && !context.computedOptions.includeResponses.includes(code)) {
+          return;
+        }
+  
         let originalRequestHeaders = [],
           originalRequestQueryParams = this.convertToPmQueryArray(reqParams, REQUEST_TYPE.EXAMPLE,
             components, options, schemaCache);

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -1787,6 +1787,10 @@ let QUERYPARAM = 'query',
       requestAcceptHeader;
 
     _.forOwn(operationItem.responses, (responseObj, code) => {
+      if (context.computedOptions.includeResponses && !context.computedOptions.includeResponses.includes(code)) {
+        return;
+      }
+
       let response,
         responseSchema = _.has(responseObj, '$ref') ? resolveSchema(context, responseObj) : responseObj,
         { includeAuthInfoInExample } = context.computedOptions,


### PR DESCRIPTION
Added new option `includeResponses`:
* Filter responses in generated collection by status code
* *Type*: array
* *Allowed values*: numbers
* If null(not set) - default behavior

Example of usage:

    ./bin/openapi2postmanv2.js -s spec.yml -o out.json -p -O folderStrategy=tagGroup,includeResponses=[200]